### PR TITLE
Updated to las2peer 1.0.0 and updated ivysettings

### DIFF
--- a/backend/.classpath
+++ b/backend/.classpath
@@ -4,7 +4,7 @@
   <classpathentry kind="src" path="src/test"/>
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
   <classpathentry kind="lib" path="lib/junit-4.12.jar"/>
-  <classpathentry kind="lib" path="lib/las2peer-bundle-0.8.2.jar"/>
+  <classpathentry kind="lib" path="lib/las2peer-bundle-1.0.0.jar"/>
   $Database_Libraries$
   <classpathentry kind="lib" path="lib/json-simple-1.1.1.jar"/>
   <classpathentry kind="output" path="output"/>

--- a/backend/etc/ivy/ivy.xml
+++ b/backend/etc/ivy/ivy.xml
@@ -9,7 +9,7 @@
     <artifact type="jar" ext="jar" conf="*" />
   </publications>
   <dependencies>
-    <dependency org="i5" name="las2peer-bundle" rev="0.8.2" changing="true" conf="platform->*"/>
+    <dependency org="i5" name="las2peer-bundle" rev="1.0.0" changing="true" conf="platform->*"/>
     <dependency org="junit" name="junit" rev="4.12" conf="platform->*"/>
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="1.1.1" conf="bundle->default"/>
 

--- a/backend/etc/ivy/ivysettings.xml
+++ b/backend/etc/ivy/ivysettings.xml
@@ -4,9 +4,9 @@
     <chain name="chain">
       <ibiblio name="central" m2compatible="true" />
       <ibiblio name="acis-internal" m2compatible="true"
-        root="http://role.dbis.rwth-aachen.de:9911/archiva/repository/internal/" />
+        root="https://archiva.dbis.rwth-aachen.de:9911/repository/internal/" />
       <ibiblio name="acis-snapshots" m2compatible="true"
-        root="http://role.dbis.rwth-aachen.de:9911/archiva/repository/snapshots/" />
+        root="https://archiva.dbis.rwth-aachen.de:9911/repository/snapshots/" />
     </chain>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
Microservices generated using the templates now use las2peer version 1.0.0.
To be able to download the latest las2peer .jar files it was necessary to update the repository URL in ivysettings.